### PR TITLE
Support initial value being null on array_reduce

### DIFF
--- a/src/SentryHandler.php
+++ b/src/SentryHandler.php
@@ -52,7 +52,7 @@ class SentryHandler extends AbstractProcessingHandler
         $main = array_reduce(
             $records,
             static function ($highest, $record) {
-                if ($record['level'] > $highest['level']) {
+                if ($highest === null || $record['level'] > $highest['level']) {
                     return $record;
                 }
 

--- a/src/SentryHandler.php
+++ b/src/SentryHandler.php
@@ -52,7 +52,7 @@ class SentryHandler extends AbstractProcessingHandler
         $main = array_reduce(
             $records,
             static function ($highest, $record) {
-                if ($highest === null || $record['level'] > $highest['level']) {
+                if (null === $highest || $record['level'] > $highest['level']) {
                     return $record;
                 }
 


### PR DESCRIPTION
Trying to avoid notices. 

I'm on an environment on which notices result into exceptions, on PHP7.4 this results into a `Trying to access array offset on value of type null in` notice.