### PR TITLE
📝 Update Symfony guide

### DIFF
--- a/doc/guide-symfony.md
+++ b/doc/guide-symfony.md
@@ -78,6 +78,8 @@ services:
     Sentry\Integration\RequestIntegration:
     Sentry\Integration\EnvironmentIntegration:
     Sentry\Integration\FrameContextifierIntegration:
+    Sentry\Integration\RequestFetcherInterface:
+        class: Sentry\Integration\RequestFetcher
 ```
 
 Let's explain the Monolog config:


### PR DESCRIPTION
Set class of RequestFetcherInterface to the SDK one instead of SentryBundle one by default to have headers and body present in Sentry